### PR TITLE
bugfix: TF_CONFIG error when enable evaluator

### DIFF
--- a/pkg/controller.v1/tensorflow/tensorflow.go
+++ b/pkg/controller.v1/tensorflow/tensorflow.go
@@ -85,7 +85,7 @@ func genTFConfigJSONStr(tfjob *tfv1.TFJob, rtype, index string) (string, error) 
 	tfConfig := TFConfig{
 		Cluster: cluster,
 		Task: TaskSpec{
-			Type:  rtype,
+			Type:  strings.ToLower(rtype),
 			Index: int(i),
 		},
 		// We need to set environment to cloud  otherwise it will default to local which isn't what we want.
@@ -107,11 +107,13 @@ func genClusterSpec(tfjob *tfv1.TFJob) (ClusterSpec, error) {
 	clusterSpec := make(ClusterSpec)
 
 	for rtype, spec := range tfjob.Spec.TFReplicaSpecs {
-		if rtype == tfv1.TFReplicaTypeEval {
-			// https://www.tensorflow.org/api_docs/python/tf/estimator/RunConfig
-			// evaluator is not part of training cluster
-			continue
-		}
+		// fix issue https://github.com/kubeflow/training-operator/issues/1139
+		// NOTE: may incompatible with tf version <= 1.12
+		//if rtype == tfv1.TFReplicaTypeEval {
+		//	// https://www.tensorflow.org/api_docs/python/tf/estimator/RunConfig
+		//	// evaluator is not part of training cluster
+		//	continue
+		//}
 		rt := strings.ToLower(string(rtype))
 		replicaNames := make([]string, 0, *spec.Replicas)
 


### PR DESCRIPTION
Relative issue https://github.com/kubeflow/training-operator/issues/1139

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/training/server_lib.py", line 427, in task_address
    job = self._cluster_spec[job_name]
KeyError: 'evaluator'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "code/tensorflow-fashion-mnist-sample/fashion_mnist_tf_estimator.py", line 94, in <module>
    eval_spec)
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_estimator/python/estimator/training.py", line 464, in train_and_evaluate
    estimator, train_spec, eval_spec, _TrainingExecutor)
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/distribute/estimator_training.py", line 290, in train_and_evaluate
    session_config=run_config.session_config)
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/distribute/distribute_coordinator.py", line 848, in run_distribute_coordinator
    environment=environment)
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/distribute/distribute_coordinator.py", line 414, in _run_std_server
    target = cluster_spec.task_address(task_type, task_id)
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/training/server_lib.py", line 429, in task_address
    raise ValueError("No such job in cluster: %r" % job_name)
ValueError: No such job in cluster: 'evaluator'