### PR TITLE
Fix activeDeadline would be triggered even after the job is completed.

### DIFF
--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -592,7 +592,7 @@ func (tc *TFController) pastBackoffLimit(tfjob *tfv1.TFJob, pods []*v1.Pod) (boo
 
 // pastActiveDeadline checks if job has ActiveDeadlineSeconds field set and if it is exceeded.
 func (tc *TFController) pastActiveDeadline(tfjob *tfv1.TFJob) bool {
-	if tfjob.Spec.ActiveDeadlineSeconds == nil || tfjob.Status.StartTime == nil {
+	if tfjob.Spec.ActiveDeadlineSeconds == nil || tfjob.Status.StartTime == nil || tfjob.Status.CompletionTime != nil {
 		return false
 	}
 	now := metav1.Now()


### PR DESCRIPTION
If both ActiveDeadline and TTLSecondsAfterFinished are set simultaneously, ActiveDeadline may still be triggered when TTLSecondsAfterFinished is activated because the calculation of ActiveDeadline does not take into account whether the job has already completed.