### PR TITLE
Fix: tfjob gets stuck in running state when succeeded pods are garbage collected

### DIFF
--- a/manifests/base/crds/kubeflow.org_tfjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_tfjobs.yaml
@@ -4340,6 +4340,10 @@ spec:
                       description: The number of pods which reached phase Failed.
                       format: int32
                       type: integer
+                    pending:
+                      description: The number of pending pods.
+                      format: int32
+                      type: integer
                     succeeded:
                       description: The number of pods which reached phase Succeeded.
                       format: int32

--- a/pkg/apis/common/v1/types.go
+++ b/pkg/apis/common/v1/types.go
@@ -49,6 +49,9 @@ type ReplicaType string
 
 // ReplicaStatus represents the current observed state of the replica.
 type ReplicaStatus struct {
+	// The number of pending pods.
+	Pending int32 `json:"pending,omitempty"`
+
 	// The number of actively running pods.
 	Active int32 `json:"active,omitempty"`
 

--- a/pkg/controller.v1/tensorflow/status.go
+++ b/pkg/controller.v1/tensorflow/status.go
@@ -99,10 +99,16 @@ func (tc *TFController) updateStatusSingle(tfjob *tfv1.TFJob, rtype tfv1.TFRepli
 			}
 		}
 	} else if rtype == tfv1.TFReplicaTypeWorker {
+		successPolicy := tfv1.SuccessPolicyDefault
+		if tfjob.Spec.SuccessPolicy != nil {
+			successPolicy = *tfjob.Spec.SuccessPolicy
+		}
 		// Leave a succeeded condition for the following two cases:
-		// 1. If success policy `SuccessPolicyAllWorkers` is used and no workers are pending, running or failed.
-		// 2. If default success policy is used and worker 0 has completed.
-		if isRunning(tfjob.Status) && (pending+running+failed == 0) || (worker0Completed && (tfjob.Spec.SuccessPolicy == nil || *tfjob.Spec.SuccessPolicy != tfv1.SuccessPolicyAllWorkers)) {
+		// 1. If success policy `SuccessPolicyDefault` is used and worker 0 has completed.
+		// 2. If success policy `SuccessPolicyAllWorkers` is used and no workers are pending, running or failed.
+		if succeeded == replicas ||
+			(successPolicy == tfv1.SuccessPolicyDefault && worker0Completed) ||
+			(successPolicy == tfv1.SuccessPolicyAllWorkers && isRunning(tfjob.Status) && (pending+running+failed == 0)) {
 			msg := fmt.Sprintf("TFJob %s successfully completed.", tfjob.Name)
 			tc.Recorder.Event(tfjob, corev1.EventTypeNormal, tfJobSucceededReason, msg)
 			if tfjob.Status.CompletionTime == nil {

--- a/pkg/controller.v1/tensorflow/status.go
+++ b/pkg/controller.v1/tensorflow/status.go
@@ -43,6 +43,7 @@ const (
 
 // updateStatus updates the status of the tfjob.
 func (tc *TFController) updateStatusSingle(tfjob *tfv1.TFJob, rtype tfv1.TFReplicaType, replicas int, restart, worker0Completed bool) error {
+	logger := tflogger.LoggerForJob(tfjob)
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for tfjob object %#v: %v", tfjob, err))
@@ -50,13 +51,12 @@ func (tc *TFController) updateStatusSingle(tfjob *tfv1.TFJob, rtype tfv1.TFRepli
 	}
 
 	commonType := common.ReplicaType(rtype)
-	// Expect to have `replicas - succeeded` pods alive.
-	expected := replicas - int(tfjob.Status.ReplicaStatuses[commonType].Succeeded)
+	pending := int(tfjob.Status.ReplicaStatuses[commonType].Pending)
 	running := int(tfjob.Status.ReplicaStatuses[commonType].Active)
+	succeeded := int(tfjob.Status.ReplicaStatuses[commonType].Succeeded)
 	failed := int(tfjob.Status.ReplicaStatuses[commonType].Failed)
+	logger.Infof("TFJob=%s, ReplicaType=%s, replicas=%d, pending=%d, running=%d, succeeded=%d, failed=%d", tfjob.Name, rtype, replicas, pending, running, succeeded, failed)
 
-	tflogger.LoggerForJob(tfjob).Infof("TFJob=%s, ReplicaType=%s expected=%d, running=%d, failed=%d",
-		tfjob.Name, rtype, expected, running, failed)
 	// set StartTime.
 	if tfjob.Status.StartTime == nil {
 		now := metav1.Now()
@@ -80,53 +80,46 @@ func (tc *TFController) updateStatusSingle(tfjob *tfv1.TFJob, rtype tfv1.TFRepli
 		if tfv1.IsChieforMaster(rtype) {
 			if running > 0 {
 				msg := fmt.Sprintf("TFJob %s is running.", tfjob.Name)
-				err := updateTFJobConditions(tfjob, common.JobRunning, tfJobRunningReason, msg)
-				if err != nil {
-					tflogger.LoggerForJob(tfjob).Infof("Append tfjob condition error: %v", err)
+				if err := updateTFJobConditions(tfjob, common.JobRunning, tfJobRunningReason, msg); err != nil {
+					logger.Infof("Append tfjob condition error: %v", err)
 					return err
 				}
-			}
-			if expected == 0 {
+			} else if succeeded == replicas {
 				msg := fmt.Sprintf("TFJob %s successfully completed.", tfjob.Name)
 				tc.Recorder.Event(tfjob, corev1.EventTypeNormal, tfJobSucceededReason, msg)
 				if tfjob.Status.CompletionTime == nil {
 					now := metav1.Now()
 					tfjob.Status.CompletionTime = &now
 				}
-				err := updateTFJobConditions(tfjob, common.JobSucceeded, tfJobSucceededReason, msg)
-				if err != nil {
-					tflogger.LoggerForJob(tfjob).Infof("Append tfjob condition error: %v", err)
+				if err := updateTFJobConditions(tfjob, common.JobSucceeded, tfJobSucceededReason, msg); err != nil {
+					logger.Infof("Append tfjob condition error: %v", err)
 					return err
 				}
 				SuccessfulTFJobsCounterInc(tfjob.Namespace)
 			}
 		}
-	} else {
-		if rtype == tfv1.TFReplicaTypeWorker {
-			// Leave a succeeded condition for the following two cases:
-			// 1. If default success policy is used and worker 0 has completed.
-			// 2. If `SuccessPolicyAllWorkers` success policy is used and all workers are succeeded.
-			if expected == 0 || (worker0Completed && (tfjob.Spec.SuccessPolicy == nil || *tfjob.Spec.SuccessPolicy != tfv1.SuccessPolicyAllWorkers)) {
-				msg := fmt.Sprintf("TFJob %s successfully completed.", tfjob.Name)
-				tc.Recorder.Event(tfjob, corev1.EventTypeNormal, tfJobSucceededReason, msg)
-				if tfjob.Status.CompletionTime == nil {
-					now := metav1.Now()
-					tfjob.Status.CompletionTime = &now
-				}
-				err := updateTFJobConditions(tfjob, common.JobSucceeded, tfJobSucceededReason, msg)
-				if err != nil {
-					tflogger.LoggerForJob(tfjob).Infof("Append tfjob condition error: %v", err)
-					return err
-				}
-				SuccessfulTFJobsCounterInc(tfjob.Namespace)
-			} else if running > 0 {
-				// Some workers are still running, leave a running condition.
-				msg := fmt.Sprintf("TFJob %s is running.", tfjob.Name)
-				err := updateTFJobConditions(tfjob, common.JobRunning, tfJobRunningReason, msg)
-				if err != nil {
-					tflogger.LoggerForJob(tfjob).Infof("Append tfjob condition error: %v", err)
-					return err
-				}
+	} else if rtype == tfv1.TFReplicaTypeWorker {
+		// Leave a succeeded condition for the following two cases:
+		// 1. If success policy `SuccessPolicyAllWorkers` is used and no workers are pending, running or failed.
+		// 2. If default success policy is used and worker 0 has completed.
+		if isRunning(tfjob.Status) && (pending+running+failed == 0) || (worker0Completed && (tfjob.Spec.SuccessPolicy == nil || *tfjob.Spec.SuccessPolicy != tfv1.SuccessPolicyAllWorkers)) {
+			msg := fmt.Sprintf("TFJob %s successfully completed.", tfjob.Name)
+			tc.Recorder.Event(tfjob, corev1.EventTypeNormal, tfJobSucceededReason, msg)
+			if tfjob.Status.CompletionTime == nil {
+				now := metav1.Now()
+				tfjob.Status.CompletionTime = &now
+			}
+			if err := updateTFJobConditions(tfjob, common.JobSucceeded, tfJobSucceededReason, msg); err != nil {
+				logger.Infof("Append tfjob condition error: %v", err)
+				return err
+			}
+			SuccessfulTFJobsCounterInc(tfjob.Namespace)
+		} else if running > 0 {
+			// Some workers are still running, leave a running condition.
+			msg := fmt.Sprintf("TFJob %s is running.", tfjob.Name)
+			if err := updateTFJobConditions(tfjob, common.JobRunning, tfJobRunningReason, msg); err != nil {
+				logger.Infof("Append tfjob condition error: %v", err)
+				return err
 			}
 		}
 	}
@@ -136,9 +129,8 @@ func (tc *TFController) updateStatusSingle(tfjob *tfv1.TFJob, rtype tfv1.TFRepli
 			msg := fmt.Sprintf("TFJob %s is restarting because %d %s replica(s) failed.",
 				tfjob.Name, failed, rtype)
 			tc.Recorder.Event(tfjob, corev1.EventTypeWarning, tfJobRestartingReason, msg)
-			err := updateTFJobConditions(tfjob, common.JobRestarting, tfJobRestartingReason, msg)
-			if err != nil {
-				tflogger.LoggerForJob(tfjob).Infof("Append tfjob condition error: %v", err)
+			if err := updateTFJobConditions(tfjob, common.JobRestarting, tfJobRestartingReason, msg); err != nil {
+				logger.Infof("Append tfjob condition error: %v", err)
 				return err
 			}
 			FailedTFJobsCounterInc(tfjob.Namespace, tfjob.Name)
@@ -151,14 +143,14 @@ func (tc *TFController) updateStatusSingle(tfjob *tfv1.TFJob, rtype tfv1.TFRepli
 				now := metav1.Now()
 				tfjob.Status.CompletionTime = &now
 			}
-			err := updateTFJobConditions(tfjob, common.JobFailed, tfJobFailedReason, msg)
-			if err != nil {
-				tflogger.LoggerForJob(tfjob).Infof("Append tfjob condition error: %v", err)
+			if err := updateTFJobConditions(tfjob, common.JobFailed, tfJobFailedReason, msg); err != nil {
+				logger.Infof("Append tfjob condition error: %v", err)
 				return err
 			}
 			FailedTFJobsCounterInc(tfjob.Namespace, tfjob.Name)
 		}
 	}
+
 	return nil
 }
 
@@ -189,6 +181,8 @@ func initializeTFReplicaStatuses(tfjob *tfv1.TFJob, rtype tfv1.TFReplicaType) {
 func updateTFJobReplicaStatuses(tfjob *tfv1.TFJob, rtype tfv1.TFReplicaType, pod *corev1.Pod) {
 	commonType := common.ReplicaType(rtype)
 	switch pod.Status.Phase {
+	case corev1.PodPending:
+		tfjob.Status.ReplicaStatuses[commonType].Pending++
 	case corev1.PodRunning:
 		tfjob.Status.ReplicaStatuses[commonType].Active++
 	case corev1.PodSucceeded:
@@ -227,6 +221,11 @@ func hasCondition(status common.JobStatus, condType common.JobConditionType) boo
 		}
 	}
 	return false
+}
+
+// isRunning checks if the job is running.
+func isRunning(status common.JobStatus) bool {
+	return hasCondition(status, common.JobRunning)
 }
 
 func isSucceeded(status common.JobStatus) bool {


### PR DESCRIPTION
## Bug Reproduction

Create a TFJob as following:

```yaml
apiVersion: kubeflow.org/v1
kind: TFJob
metadata:
  name: test
  namespace: default
spec:
  successPolicy: AllWorkers
  tfReplicaSpecs:
    Worker:
      replicas: 3
      restartPolicy: Never
      template:
        metadata:
          labels:
            pod-group.scheduling.sigs.k8s.io/name: test
            pod-group.scheduling.sigs.k8s.io/min-available: "3"
        spec:
          containers:
          - name: tensorflow
            image: ubuntu:22.04
            command:
            - bash
            - -c
            args:
            - |
              t=$((((RANDOM % 3) + 2) * 10))
              echo "sleep $t seconds..."
              sleep $t
```

Delete any worker pod once it completed, then the tfjob will get stuck in running state forever. This mimics the situation that worker pods are garbage collected very soon when the k8s cluster has more than 12500 (default GC threshold) completed pods.

## Proposed Changes

- Add new field `.status.replicaStatuses.pending` to count pending pods
- Fix bug: tfjob will get stuck in running state when succeeded pods get garbage collected
  - Before: tfjob is `Succeeded` when `expected==0`, which means number of succeeded pods equals to replicas.
  - After: tfjob is `Succeeded` when the job is in `Running` state and no pods are pending, running or failed.