### PR TITLE
Fix integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,16 @@ GIT_REPO := $(shell git remote -v | awk '{print $$2}' | head -n1)
 GIT_BRANCH := $(shell git branch --show-current)
 GIT_SHORT_COMMIT_ID := $(shell git rev-parse --short HEAD)
 
+# Location to install binaries
+LOCALBIN ?= $(shell pwd)/bin
+
 # Versions
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 
 # Binaries
+TF_OPERATOR ?= $(LOCALBIN)/tf-operator
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
 
-# Location to install binaries
-LOCALBIN ?= $(shell pwd)/bin
 
 IMG ?= registry.cn-beijing.aliyuncs.com/acs/tf_operator
 VERSION ?= v1.0-aliyun

--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -44,7 +44,6 @@ import (
 	tfjoblisters "github.com/kubeflow/tf-operator/pkg/client/listers/tensorflow/v1"
 	"github.com/kubeflow/tf-operator/pkg/common/jobcontroller"
 	tflogger "github.com/kubeflow/tf-operator/pkg/logger"
-	"github.com/kubeflow/tf-operator/pkg/util"
 	"github.com/kubeflow/tf-operator/pkg/util/k8sutil"
 )
 
@@ -539,13 +538,6 @@ func (tc *TFController) satisfiedExpectations(tfjob *tfv1.TFJob) bool {
 		// Check the expectations of the services.
 		expectationServicesKey := jobcontroller.GenExpectationServicesKey(tfjobKey, string(rtype))
 		satisfied = satisfied || tc.Expectations.SatisfiedExpectations(expectationServicesKey)
-	}
-
-	cleanPodPolicyNone := tfjob.Spec.CleanPodPolicy != nil && *tfjob.Spec.CleanPodPolicy == common.CleanPodPolicyNone
-	if util.CheckJobCompletedV1(tfjob.Status.Conditions) && tfjob.DeletionTimestamp == nil &&
-		(cleanPodPolicyNone || tfjob.Annotations[TFCleanPodStatusLabel] == TFCleanStatusDone) &&
-		tfjob.Spec.TTLSecondsAfterFinished == nil {
-		satisfied = false
 	}
 
 	return satisfied

--- a/pkg/controller.v1/tensorflow/job.go
+++ b/pkg/controller.v1/tensorflow/job.go
@@ -2,7 +2,6 @@ package tensorflow
 
 import (
 	"fmt"
-	"reflect"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -204,19 +203,11 @@ func (tc *TFController) deletePodsAndServices(tfJob *tfv1.TFJob, pods []*corev1.
 		return fmt.Errorf("the clean pod policy %s is not supported", cleanPodPolicy)
 	}
 
-	tfjobToUpdate := tfJob.DeepCopy()
-
-	if tfjobToUpdate.Annotations == nil {
-		tfjobToUpdate.Annotations = map[string]string{}
+	// Add a label to mark pods have already been cleaned up.
+	if tfJob.Annotations == nil {
+		tfJob.Annotations = map[string]string{}
 	}
-
-	tfjobToUpdate.Annotations[TFCleanPodStatusLabel] = TFCleanStatusDone
-	if !reflect.DeepEqual(tfJob, tfjobToUpdate) {
-		_, err := tc.tfJobClientSet.KubeflowV1().TFJobs(tfjobToUpdate.Namespace).Update(tfjobToUpdate)
-		if err != nil {
-			return err
-		}
-	}
+	tfJob.Annotations[TFCleanPodStatusLabel] = TFCleanStatusDone
 
 	return nil
 }

--- a/pkg/controller.v1/tensorflow/job_test.go
+++ b/pkg/controller.v1/tensorflow/job_test.go
@@ -253,7 +253,8 @@ func TestDeletePodsAndServices(t *testing.T) {
 			activeWorkerServices: 4,
 			activePSServices:     2,
 
-			expectedPodDeletions: 6,
+			expectedPodDeletions:     6,
+			expectedServiceDeletions: 6,
 		},
 		{
 			description: "4 workers and 2 ps is succeeded, policy is running",
@@ -338,9 +339,8 @@ func TestDeletePodsAndServices(t *testing.T) {
 		}
 
 		// Set succeeded to run the logic about deleting.
-		err := updateTFJobConditions(tc.tfJob, common.JobSucceeded, tfJobSucceededReason, "")
-		if err != nil {
-			t.Errorf("Append tfjob condition error: %v", err)
+		if err := updateTFJobConditions(tc.tfJob, common.JobSucceeded, tfJobSucceededReason, ""); err != nil {
+			t.Errorf("Failed to append tfjob condition: %v", err)
 		}
 
 		unstructured, err := testutil.ConvertTFJobToUnstructured(tc.tfJob)
@@ -369,10 +369,10 @@ func TestDeletePodsAndServices(t *testing.T) {
 		}
 
 		if len(fakePodControl.DeletePodName) != tc.expectedPodDeletions {
-			t.Errorf("%s: unexpected number of pod deletes.  Expected %d, saw %d\n", tc.description, tc.expectedPodDeletions, len(fakePodControl.DeletePodName))
+			t.Errorf("%s: unexpected number of pod deletes. Expected %d, saw %d\n", tc.description, tc.expectedPodDeletions, len(fakePodControl.DeletePodName))
 		}
-		if len(fakeServiceControl.DeleteServiceName) != tc.expectedPodDeletions {
-			t.Errorf("%s: unexpected number of service deletes.  Expected %d, saw %d\n", tc.description, tc.expectedPodDeletions, len(fakeServiceControl.DeleteServiceName))
+		if len(fakeServiceControl.DeleteServiceName) != tc.expectedServiceDeletions {
+			t.Errorf("%s: unexpected number of service deletes. Expected %d, saw %d\n", tc.description, tc.expectedServiceDeletions, len(fakeServiceControl.DeleteServiceName))
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Fix Go unit tests:

- Jobs in `Succeeded` or `Failed` state will be reconciled at lest once.
- Will not send update request when `deletePodAndServices`.

Fix Makefile:

- `make build-operator` does not work.