### PR TITLE
Bump golang version from 1.18 to 1.23.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder 
+FROM golang:1.23.12 as builder 
 
 WORKDIR /workspace
 

--- a/dashboard/backend/handler/api_handler.go
+++ b/dashboard/backend/handler/api_handler.go
@@ -1,4 +1,4 @@
-//Package handler is a package handling API requests for managing TFJobs.
+// Package handler is a package handling API requests for managing TFJobs.
 // The primary purpose of handler is implementing the functionality needed by the TFJobs dashboard.
 package handler
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/tf-operator
 
-go 1.18
+go 1.23.12
 
 require (
 	github.com/emicklei/go-restful v2.16.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,7 @@ go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
@@ -340,6 +341,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/control/service_ref_manager.go
+++ b/pkg/control/service_ref_manager.go
@@ -45,8 +45,9 @@ type ServiceControllerRefManager struct {
 // If canAdopt() returns a non-nil error, all adoptions will fail.
 //
 // NOTE: Once canAdopt() is called, it will not be called again by the same
-//       ServiceControllerRefManager instance. Create a new instance if it makes
-//       sense to check canAdopt() again (e.g. in a different sync pass).
+//
+//	ServiceControllerRefManager instance. Create a new instance if it makes
+//	sense to check canAdopt() again (e.g. in a different sync pass).
 func NewServiceControllerRefManager(
 	serviceControl ServiceControlInterface,
 	ctr metav1.Object,
@@ -68,8 +69,8 @@ func NewServiceControllerRefManager(
 // ClaimServices tries to take ownership of a list of Services.
 //
 // It will reconcile the following:
-//   * Adopt orphans if the selector matches.
-//   * Release owned objects if the selector no longer matches.
+//   - Adopt orphans if the selector matches.
+//   - Release owned objects if the selector no longer matches.
 //
 // Optional: If one or more filters are specified, a Service will only be claimed if
 // all filters return true.

--- a/pkg/controller.v1/tensorflow/tensorflow.go
+++ b/pkg/controller.v1/tensorflow/tensorflow.go
@@ -59,17 +59,18 @@ type TaskSpec struct {
 }
 
 // genTFConfig will generate the environment variable TF_CONFIG
-// {
-//     "cluster": {
-//         "ps": ["ps1:2222", "ps2:2222"],
-//         "worker": ["worker1:2222", "worker2:2222", "worker3:2222"]
-//     },
-//     "task": {
-//         "type": "ps",
-//         "index": 1
-//         },
-//     }
-// }
+//
+//	{
+//	    "cluster": {
+//	        "ps": ["ps1:2222", "ps2:2222"],
+//	        "worker": ["worker1:2222", "worker2:2222", "worker3:2222"]
+//	    },
+//	    "task": {
+//	        "type": "ps",
+//	        "index": 1
+//	        },
+//	    }
+//	}
 func genTFConfigJSONStr(tfjob *tfv1.TFJob, rtype, index string) (string, error) {
 	// Configure the TFCONFIG environment variable.
 	i, err := strconv.ParseInt(index, 0, 32)


### PR DESCRIPTION
## Proposed Changes

- Bump golang version from `1.18` to `1.23.12`.